### PR TITLE
improve the performance of the tasks_time_intervals dataframe

### DIFF
--- a/ipynb/trappy/Energy_Measurements.ipynb
+++ b/ipynb/trappy/Energy_Measurements.ipynb
@@ -1099,11 +1099,11 @@
    "outputs": [],
    "source": [
     "# Compute intervals of time in which CPU0 is not IDLE\n",
-    "tasks_time_intervals = pd.DataFrame(columns=['start', 'end', 'time_interval'])\n",
-    "i = 0\n",
-    "for t1, t2 in zip(idle_tasks.index, next_idle_tasks.index):\n",
-    "    tasks_time_intervals.loc[i] = [t1, t2, t2 - t1]\n",
-    "    i += 1"
+    "time_intervals = [t2 - t1 for t1, t2 in zip(idle_tasks.index, next_idle_tasks.index)]\n",
+    "tasks_time_intervals = pd.DataFrame({\n",
+    "        \"start\": idle_tasks.index[:len(time_intervals)],\n",
+    "        \"end\": next_idle_tasks.index[:len(time_intervals)],\n",
+    "        \"time_interval\": time_intervals})"
    ]
   },
   {


### PR DESCRIPTION
Appending to an existing data frame is a very expensive operation.  It's
a lot faster to create a time_intervals array and then create the
dataframe.
